### PR TITLE
Upgrading IntelliJ from 2024.2.2 to 2024.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.2.2 to 2024.2.3
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/iris-jetbrains-plugin
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 2.1.2
+pluginVersion = 2.1.3
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 242.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.2.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.2.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -33,7 +33,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.2.2
+platformVersion = 2024.2.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.2.2 to 2024.2.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662234/IntelliJ-IDEA-2024.2.3-242.23339.11-build-Release-Notes

# What's New?
<p> IntelliJ IDEA 2024.2.3 is out! This release brings a host of noteworthy fixes and improvements: </p> 
<ul> 
 <li>Remote tools, added via the <em>Tools</em> settings, are once again visible on IDE restart. [<a href="https://youtrack.jetbrains.com/issue/IJPL-161201">IJPL-161201</a>] </li>
 <li><em>JSON Schema Mappings</em> in <em>Settings</em> now load as expected. [<a href="https://youtrack.jetbrains.com/issue/IJPL-160634">IJPL-160634</a>] </li>
 <li>The IDE with the Python plugin installed once again works as expected for remote interpreter users on Windows. [<a href="https://youtrack.jetbrains.com/issue/PY-76055/IDE-crash-on-start-at-com.jetbrains.python.remote.PyRemoteSdkAdditionalData.computeFlavor">PY-76055</a>] </li>
 <li>Schema validation for Kubernetes-like files works as expected. [<a href="https://youtrack.jetbrains.com/issue/IJPL-63687">IJPL-63687</a>] </li>
 <li><em>Settings Sync</em> again works as expected. [<a href="https://youtrack.jetbrains.com/issue/IJPL-13080">IJPL-13080</a>] </li> 
</ul> 
<p> Get more details from our <a href="https://blog.jetbrains.com/idea/2024/09/intellij-idea-2024-2-3/">blog post</a>. </p>
    