### PR TITLE
Upgrading IntelliJ from 2024.3 to 2024.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.3 to 2024.3.1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/iris-jetbrains-plugin
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 2.2.0
+pluginVersion = 2.2.1
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 243.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.3,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.3.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -33,7 +33,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.3
+platformVersion = 2024.3.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.3 to 2024.3.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662317/IntelliJ-IDEA-2024.3.1-243.22562.145-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.3.1 is out! This release introduces the following feature: 
<ul>
 <li>Robust security analysis for Java and Kotlin with the “Security Analysis by Qodana” plugin</li>
</ul> and improvements: 
<ul>
 <li>JSON schema validation is now aware of YAML tags, for example, !reference in a .gitlab-ci.yml file.</li> [<a href="https://youtrack.jetbrains.com/issue/IJPL-64341">IJPL-64341</a>] 
 <li>When changing the Version Control setting for remote development environments, the Open Diff as Editor Tab checkbox now works as intended.</li> [<a href="https://youtrack.jetbrains.com/issue/IJPL-165702">IJPL-165702</a>] 
 <li>The Render documentation comments option again works as expected.</li> [<a href="https://youtrack.jetbrains.com/issue/IJPL-160370">IJPL-160370</a>] 
 <li>Settings sync again works with self-signed certificates when a proxy is used.</li> [<a href="https://youtrack.jetbrains.com/issue/IJPL-171446">IJPL-160370</a>]
</ul> Get more details from our <a href="https://blog.jetbrains.com/idea/2024/12/intellij-idea-2024-3-1/">blog post</a>
    