### PR TITLE
Upgrading IntelliJ from 2025.1.4.1 to 2025.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2025.1.4.1 to 2025.2
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,16 +8,16 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/iris-jetbrains-plugin
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 3.0.3
+pluginVersion = 3.1.0
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 251
-pluginUntilBuild = 251.*
+pluginSinceBuild = 252
+pluginUntilBuild = 252.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2025.1.4.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2025.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -33,7 +33,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2025.1.4.1
+platformVersion = 2025.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/src/main/java/com/chriscarini/jetbrains/iris/plugin/action/MultipleIncidentsAction.java
+++ b/src/main/java/com/chriscarini/jetbrains/iris/plugin/action/MultipleIncidentsAction.java
@@ -45,7 +45,7 @@ public class MultipleIncidentsAction extends NotificationAction {
             new LinkLabel<>(String.format("Claim %s", incident.getId()), IrisIcons.IrisClaim, (aSource, aLinkData) -> {
               final AnAction action = new ClaimIncidentAction(this.baseHostname, aLinkData.getId(), null);
               action.getTemplatePresentation().setEnabledAndVisible(true);
-              ActionUtil.performActionDumbAwareWithCallbacks(action, e);
+              ActionUtil.performAction(action, e);
               dialogBuilder.getDialogWrapper().close(DialogWrapper.OK_EXIT_CODE);
             }, incident);
         fb.addComponent(foo);


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.1.4.1 to 2025.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662485/IntelliJ-IDEA-2025.2-252.23892.409-build-Release-Notes

# What's New?
<p>IntelliJ IDEA 2025.2 is out! Highlights include:</p>
<ul>
 <li>Support for cutting-edge technologies: Java 25, Maven 4, and JSpecify.</li>
 <li>Major improvements for Spring developers: Spring Debugger and Spring Modulith support.</li>
 <li>Smarter AI-assisted workflows.</li>
</ul>
<p>Visit our <a href="https://www.jetbrains.com/idea/whatsnew">What's New page</a> for all details.</p>
    